### PR TITLE
add leaderboard id field to achievement backend

### DIFF
--- a/db/migration/V0077__Add_leaderboard_id_field_to_Achievement_table.SQL
+++ b/db/migration/V0077__Add_leaderboard_id_field_to_Achievement_table.SQL
@@ -1,0 +1,23 @@
+ALTER TABLE "Achievement"
+ADD COLUMN "leaderboardId" UUID,
+ADD CONSTRAINT "fk_leaderboard" FOREIGN KEY ("leaderboardId") REFERENCES "Leaderboard"(id);
+
+-- backfill
+-- all current `Achievement.name` is either
+--   "<leaderboard name> - <school> - <Nth> Place"  (tag leaderboards)
+--   "<leaderboard name> - <Nth> Place"             (global leaderboard)
+DO $$
+BEGIN
+    CASE current_database()
+        WHEN 'codebloom-prod' THEN
+            UPDATE "Achievement" a
+            SET "leaderboardId" = l.id
+            FROM "Leaderboard" l
+            WHERE l.name = split_part(a.title, ' - ', 1);
+        ELSE
+            RAISE NOTICE 'Skipping prod only backfill: Current database is %', current_database();
+    END CASE;
+END $$;
+
+ALTER TABLE "Achievement"
+ALTER COLUMN "leaderboardId" SET NOT NULL;

--- a/src/main/java/org/patinanetwork/codebloom/common/db/models/achievements/Achievement.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/db/models/achievements/Achievement.java
@@ -24,6 +24,9 @@ public class Achievement {
     private String userId;
 
     @NotNullColumn
+    private String leaderboardId;
+
+    @NotNullColumn
     private AchievementPlaceEnum place;
 
     /** `null` indicates global leaderboard. */

--- a/src/main/java/org/patinanetwork/codebloom/common/db/repos/achievements/AchievementRepository.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/db/repos/achievements/AchievementRepository.java
@@ -15,6 +15,7 @@ public interface AchievementRepository {
      *       <li>title
      *       <li>description
      *       <li>isActive
+     *       <li>leaderboardId
      *     </ul>
      */
     void createAchievement(Achievement achievement);
@@ -29,6 +30,7 @@ public interface AchievementRepository {
      *       <li>description
      *       <li>isActive
      *       <li>deletedAt
+     *       <li>leaderboardId
      *     </ul>
      *
      * @return updated achievement if successful

--- a/src/main/java/org/patinanetwork/codebloom/common/db/repos/achievements/AchievementSqlRepository.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/db/repos/achievements/AchievementSqlRepository.java
@@ -26,6 +26,7 @@ public class AchievementSqlRepository implements AchievementRepository {
         var title = rs.getString("title");
         var description = rs.getString("description");
         var isActive = rs.getBoolean("isActive");
+        var leaderboardId = rs.getString("leaderboardId");
         var createdAt = StandardizedOffsetDateTime.normalize(rs.getObject("createdAt", OffsetDateTime.class));
         OffsetDateTime deletedAt =
                 StandardizedOffsetDateTime.normalize(rs.getObject("deletedAt", OffsetDateTime.class));
@@ -34,6 +35,7 @@ public class AchievementSqlRepository implements AchievementRepository {
                 .userId(userId)
                 .place(place)
                 .leaderboard(leaderboard)
+                .leaderboardId(leaderboardId)
                 .title(title)
                 .description(description)
                 .isActive(isActive)
@@ -53,9 +55,9 @@ public class AchievementSqlRepository implements AchievementRepository {
         achievement.setId(UUID.randomUUID().toString());
         String sql = """
             INSERT INTO "Achievement"
-                (id, "userId", place, leaderboard, title, description, "isActive", "deletedAt")
+                (id, "userId", place, leaderboard, title, description, "isActive", "deletedAt", "leaderboardId")
             VALUES
-                (:id, :userId, :place, :leaderboard, :title, :description, :isActive, :deletedAt)
+                (:id, :userId, :place, :leaderboard, :title, :description, :isActive, :deletedAt, :leaderboardId)
             RETURNING
                 "createdAt"
             """;
@@ -71,6 +73,7 @@ public class AchievementSqlRepository implements AchievementRepository {
                                 .map(Enum::name)
                                 .orElse(null),
                         Types.OTHER)
+                .param("leaderboardId", achievement.getLeaderboardId())
                 .param("title", achievement.getTitle())
                 .param("description", achievement.getDescription())
                 .param("isActive", achievement.isActive())
@@ -94,7 +97,8 @@ public class AchievementSqlRepository implements AchievementRepository {
                 title = :title,
                 description = :description,
                 "isActive" = :isActive,
-                "deletedAt" = :deletedAt
+                "deletedAt" = :deletedAt,
+                "leaderboardId" = :leaderboardId
             WHERE
                 id = :id
             """;
@@ -108,6 +112,7 @@ public class AchievementSqlRepository implements AchievementRepository {
                                 .map(Enum::name)
                                 .orElse(null),
                         Types.OTHER)
+                .param("leaderboardId", achievement.getLeaderboardId())
                 .param("title", achievement.getTitle())
                 .param("description", achievement.getDescription())
                 .param("isActive", achievement.isActive())
@@ -150,7 +155,8 @@ public class AchievementSqlRepository implements AchievementRepository {
                 description,
                 "isActive",
                 "createdAt",
-                "deletedAt"
+                "deletedAt",
+                "leaderboardId"
             FROM
                 "Achievement"
             WHERE
@@ -178,7 +184,8 @@ public class AchievementSqlRepository implements AchievementRepository {
                 description,
                 "isActive",
                 "createdAt",
-                "deletedAt"
+                "deletedAt",
+                "leaderboardId"
             FROM
                 "Achievement"
             WHERE

--- a/src/main/java/org/patinanetwork/codebloom/common/dto/achievement/AchievementDto.java
+++ b/src/main/java/org/patinanetwork/codebloom/common/dto/achievement/AchievementDto.java
@@ -31,6 +31,9 @@ public class AchievementDto {
     private Tag leaderboard;
 
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+    private String leaderboardId;
+
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private String title;
 
     @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
@@ -52,6 +55,7 @@ public class AchievementDto {
                 .leaderboard(achievement.getLeaderboard())
                 .place(achievement.getPlace())
                 .title(achievement.getTitle())
+                .leaderboardId(achievement.getLeaderboardId())
                 .description(achievement.getDescription())
                 .isActive(achievement.isActive())
                 .createdAt(achievement.getCreatedAt())


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes

## Checklist before review

- [ ] I have done a thorough self-review of the PR
- [ ] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [ ] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [ ] All tests have passed
- [ ] I have successfully deployed this PR to staging
- [ ] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<img width="557" height="244" alt="image" src="https://github.com/user-attachments/assets/97b3ac9c-887f-4899-bb80-b4b5802414db" />

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>