### PR TITLE
TAN-978: move discord standup bot to saturday instead of weds

### DIFF
--- a/internal/standup-bot/src/common/standup/mod.rs
+++ b/internal/standup-bot/src/common/standup/mod.rs
@@ -12,7 +12,7 @@ pub fn is_time_to_send_standup_message(last_standup_time: Option<DateTime<Utc>>)
     let weekday = now.weekday();
     let hour = now.hour();
 
-    let is_standup_day = weekday == Weekday::Wed;
+    let is_standup_day = weekday == Weekday::Sat;
     let is_standup_time = hour >= 12;
 
     if !(is_standup_day && is_standup_time) {


### PR DESCRIPTION
<!-- DO NOT EDIT THE NEXT LINE. IT WILL BE AUTOMATICALLY SYNCED -->
<!-- https://codebloom.notion.site/Render-achievements-to-user-profile-page-2a87c85563aa806ab7c0efa9cca47309 -->

## Description of changes
move standup bot in discord to run on saturdays instead of wednesday because we moved out stand up time
## Checklist before review

- [ ] I have done a thorough self-review of the PR
- [ ] Copilot has reviewed my latest changes, and all comments have been fixed and/or closed.
- [ ] If I have made database changes, I have made sure I followed all the db repo rules listed in the wiki [here](https://github.com/tahminator/codebloom/wiki/Database-Repository-Best-Practices). (check if no db changes)
- [ ] All tests have passed
- [ ] I have successfully deployed this PR to staging
- [ ] I have done manual QA in both dev (and staging if possible) and attached screenshots below.

## Screenshots

### Dev

<!-- Screenshots go here -->

### Staging

<!-- Screenshots go here. If you cannot meaningfully test in staging, please indicate why here. -->
